### PR TITLE
remove copy paste error left over from guessing game.

### DIFF
--- a/chapter6/source.rkt
+++ b/chapter6/source.rkt
@@ -23,7 +23,6 @@
    Run and evaluate 
      (start-snake)
    This will pop up a window with instructions for interacting with the program. 
-   Watch how qiuckly the program guesses X. 
 |#
 
 ;


### PR DESCRIPTION
It looks like this line belongs to the guessing games source and not the snake game.
Have removed the line from the snake game source code.
